### PR TITLE
Update backup.sh and restore.sh to work with latest Ghost Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create and run the ghost-backup container with the volumes from your Ghost data 
 
 Where:
 
-`<your-data-container>` is either your Ghost blog container, or a separate data-only container holding your blog files. Basically, wheverever your blog content lives.
+`<your-data-container>` is either your Ghost blog container, or a separate data-only container holding your blog files. Basically, wherever your blog content lives.
 
 That's it! This will create and run a container named 'ghost-backup' which will create a backup of your Ghost database and content files under /backups every day at 3am.
 

--- a/backup.sh
+++ b/backup.sh
@@ -18,7 +18,7 @@ backupDB () {
   if [ -z $MYSQL_NAME ]; then
     # sqlite
     log " creating ghost db archive (sqlite)..."
-    cd $GHOST_LOCATION/data && sqlite3 ghost.db ".backup temp.db" && gzip -c temp.db > "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-db_$NOW.gz" && rm temp.db
+    cd $GHOST_LOCATION/content/data && sqlite3 ghost.db ".backup temp.db" && gzip -c temp.db > "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-db_$NOW.gz" && rm temp.db
   else
     # mysql/mariadb
     log " creating ghost db archive (mysql)..."
@@ -36,7 +36,8 @@ backupDB () {
 # Backup the ghost static files (images, themes, apps etc) but not the /data directory (the db backup handles that)
 backupGhost () {
   log " creating ghost files archive..."
-  tar cfz "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz" --directory=$GHOST_LOCATION --exclude='data' . 2>&1 | tee -a $LOG_LOCATION #Exclude the /data directory (we back that up separately)
+  #Exclude  /content/data  (we back that up separately),  config.production.json (config is bind-mounted), current and versions (Ghost source files from docker image), and content.orig (created upon Ghost setup)
+  tar cfz "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz" --directory=$GHOST_LOCATION --exclude='content/data' --exclude='content.orig' --exclude='current' --exclude='versions' --exclude='config.production.json' . 2>&1 | tee -a $LOG_LOCATION 
   log " ...completed: $BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz"
 }
 

--- a/backup.sh
+++ b/backup.sh
@@ -36,7 +36,7 @@ backupDB () {
 # Backup the ghost static files (images, themes, apps etc) but not the /data directory (the db backup handles that)
 backupGhost () {
   log " creating ghost files archive..."
-  #Exclude  /content/data  (we back that up separately),  config.production.json (config is bind-mounted), current and versions (Ghost source files from docker image), and content.orig (created upon Ghost setup)
+  #Exclude  /content/data  (we back that up separately), current and versions (Ghost source files from docker image), and content.orig (created when Ghost was built)
   tar cfz "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz" --directory=$GHOST_LOCATION --exclude='content/data' --exclude='content.orig' --exclude='current' --exclude='versions' . 2>&1 | tee -a $LOG_LOCATION 
   log " ...completed: $BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz"
 }

--- a/backup.sh
+++ b/backup.sh
@@ -37,7 +37,7 @@ backupDB () {
 backupGhost () {
   log " creating ghost files archive..."
   #Exclude  /content/data  (we back that up separately),  config.production.json (config is bind-mounted), current and versions (Ghost source files from docker image), and content.orig (created upon Ghost setup)
-  tar cfz "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz" --directory=$GHOST_LOCATION --exclude='content/data' --exclude='content.orig' --exclude='current' --exclude='versions' --exclude='config.production.json' . 2>&1 | tee -a $LOG_LOCATION 
+  tar cfz "$BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz" --directory=$GHOST_LOCATION --exclude='content/data' --exclude='content.orig' --exclude='current' --exclude='versions' . 2>&1 | tee -a $LOG_LOCATION 
   log " ...completed: $BACKUP_LOCATION/$BACKUP_FILE_PREFIX-ghost_$NOW.tar.gz"
 }
 

--- a/restore.sh
+++ b/restore.sh
@@ -24,7 +24,7 @@ restoreDB () {
   if [ -z $MYSQL_NAME ]; then
     # sqlite
     log "restoring data from sqlite dump file: $RESTORE_FILE"
-    cd $GHOST_LOCATION/data && gunzip -c $RESTORE_FILE > temp.db && sqlite3 ghost.db ".restore temp.db" && rm temp.db
+    cd $GHOST_LOCATION/content/data && gunzip -c $RESTORE_FILE > temp.db && sqlite3 ghost.db ".restore temp.db" && rm temp.db
     log "...restored ghost DB archive $RESTORE_FILE"
   else
     # mysql/mariadb
@@ -49,7 +49,7 @@ restoreGhost () {
     tar -xzf $RESTORE_FILE --directory=$GHOST_LOCATION --keep-newer-files --warning=no-ignore-newer 2>&1 | tee -a $LOG_LOCATION
   else
     log "removing ghost files in $GHOST_LOCATION"
-    rm -r $GHOST_LOCATION/apps/ $GHOST_LOCATION/images/ $GHOST_LOCATION/themes/ $GHOST_LOCATION/config.js #Do not remove /data
+    rm -r $GHOST_LOCATION/content/apps/ $GHOST_LOCATION/content/images/ $GHOST_LOCATION/content/themes/ #Do not remove /data or config.production.json
     log "restoring ghost files from archive file: $RESTORE_FILE"
     tar -xzf $RESTORE_FILE --directory=$GHOST_LOCATION 2>&1 | tee -a $LOG_LOCATION
   fi

--- a/restore.sh
+++ b/restore.sh
@@ -49,9 +49,9 @@ restoreGhost () {
     tar -xzf $RESTORE_FILE --directory=$GHOST_LOCATION --keep-newer-files --warning=no-ignore-newer 2>&1 | tee -a $LOG_LOCATION
   else
     log "removing ghost files in $GHOST_LOCATION"
-    rm -r $GHOST_LOCATION/content/apps/ $GHOST_LOCATION/content/images/ $GHOST_LOCATION/content/themes/ #Do not remove /data or config.production.json
+    rm -r $GHOST_LOCATION/content/apps/ $GHOST_LOCATION/content/images/ $GHOST_LOCATION/content/settings/ $GHOST_LOCATION/content/themes/ #Do not remove /data or config.production.json
     log "restoring ghost files from archive file: $RESTORE_FILE"
-    tar -xzf $RESTORE_FILE --directory=$GHOST_LOCATION 2>&1 | tee -a $LOG_LOCATION
+    tar -xzf $RESTORE_FILE --directory=$GHOST_LOCATION --exclude='config.production.json' 2>&1 | tee -a $LOG_LOCATION
   fi
 
   log "restore complete"


### PR DESCRIPTION
Hi,

This is my contribution to fix the #3 issue regarding the location of files in the latest official Docker image for Ghost.

## The problem:

The recent versions of Ghost's official docker images are (at build time):

* installing content under /var/lib/ghost/content/
* installing config file under /var/lib/ghost/config.production.json
* creating a content.orig directory in the Ghost install location
* installing its software under versions/ in the Ghost install location
* installing current symlink in the Ghost install location

Furthermore, the **config.production.json** file is not visible when mounted in other containers using ``--volumes_from``, and it is very common and good practice for the config file to be bind-mounted to the container. Either way the file cannot be removed by other containers.


In other hand, ghost-backup expects Ghost files, the sqlite3 database and a **config.js** file to be under the same **$GHOST_LOCATION** (by default **/var/lib/ghost**).

Additionally, Ghost creates a **/var/lib/ghost/content/settings** directory that ghost-backup knows nothing about, so it is not treated like the other directories upon restoring.

## The solution

**$GHOST_LOCATION** points to Ghost install directory as intended (default to /var/lib/ghost) but the backup and restore scripts knows to access the database and the files under **$GHOST_LOCATION/content/**.

Secondly, the restore script properly removes all directories (except **data/**) under **/var/lib/ghost /content/** (including **settings/**) in the default restore mode.

Finally, the **config.production.json** is backed up as part of the files backup, but when restoring from a backup archive, that file is excluded. 

Configuration file is no longer automatically restored as part of other files but if the **$BACKUP_LOCATION**  is volume-mounted from the host, it can still be manually extracted from the tarball on the host (or in my case managed by [the system that uses ghost-backup](https://gitlab.com/rijam/docker-ghost-buster/blob/master/restore_config.sh))


