### PR TITLE
Mysql 8 support, post-backup scripts, ghost 4.x API bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:bullseye
 
 LABEL org.opencontainers.image.authors="Tim Bennett"
 
@@ -7,7 +7,9 @@ WORKDIR /usr/app
 
 RUN \
   apt-get update && \
-  apt-get install -y mysql-client cron sqlite3 curl jq netcat
+  apt-get install -y --no-install-recommends wget cron sqlite3 curl jq netcat mariadb-client && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # -----------------------
 # Default configuration
@@ -57,6 +59,9 @@ ENV GHOST_COOKIE_FILE="/tmp/ghost-cookie.txt"
 # Name of the ghost session cookie expected
 ENV GHOST_ADMIN_COOKIE_NAME="ghost-admin-api-session"
 
+# Set to false to disable compressing DB dumps
+ENV COMPRESS_DB_DUMP=true
+
 # -----------------------
 
 RUN mkdir $BACKUP_LOCATION
@@ -74,8 +79,8 @@ COPY common.sh /bin/common.sh
 RUN chmod +x /bin/backup
 RUN chmod +x /bin/restore
 
-# Clean up
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Create user scripts folder
+RUN mkdir /bin/user
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Hi @bennetimo ,

I made some changes to ghost-backup so it works for my flow. Sorry for the messy PR that includes multiple changes.

I haven't actually tried if the API backup works since I use SQL backups only.

Here's the list of changes:
Bump upstream docker image to debian bullseye so we get mysql 8 support in mariadb client. Also allows armv7 and arm64 builds.
Shrink image size by cleaning dpkg caches after apt-get.
Make db compression optional.
Add possibility for post-backup user scripts.
Allow manual backup filename override.
bug fix: Don't fail if Ghost API is not configured or available.